### PR TITLE
Switch from ShortMaps to ShorterMaps

### DIFF
--- a/lib/invoice_tracker/invoice.ex
+++ b/lib/invoice_tracker/invoice.ex
@@ -2,6 +2,7 @@ defmodule InvoiceTracker.Invoice do
   @moduledoc """
   A struct for representing individual invoices.
   """
+  import ShorterMaps
 
   defstruct [:number, :amount, :date, :paid_on]
 
@@ -43,7 +44,7 @@ defmodule InvoiceTracker.Invoice do
     !paid?(invoice) || Timex.before?(date, last_activity(invoice))
   end
 
-  defp last_activity(%__MODULE__{paid_on: nil, date: date}), do: date
+  defp last_activity(~M{%__MODULE__ paid_on: nil, date}), do: date
   defp last_activity(invoice), do: invoice.paid_on
 
   @doc """

--- a/lib/invoice_tracker/invoice_reporter.ex
+++ b/lib/invoice_tracker/invoice_reporter.ex
@@ -3,7 +3,7 @@ defmodule InvoiceTracker.InvoiceReporter do
   Formats a list of invoices into an ASCII table
   """
 
-  import ShortMaps
+  import ShorterMaps
 
   alias InvoiceTracker.Invoice
   alias Number.Delimit
@@ -27,7 +27,7 @@ defmodule InvoiceTracker.InvoiceReporter do
     |> Table.render!
   end
 
-  defp format_list_row(~m{%Invoice date number amount paid_on}a) do
+  defp format_list_row(~M{%Invoice date, number, amount, paid_on}) do
     [date, number, format_amount(amount), paid_on]
   end
 

--- a/lib/invoice_tracker/time_reporter.ex
+++ b/lib/invoice_tracker/time_reporter.ex
@@ -2,7 +2,7 @@ defmodule InvoiceTracker.TimeReporter do
   @moduledoc """
   Report on the time entries that make up an invoice.
   """
-  import ShortMaps
+  import ShorterMaps
 
   alias InvoiceTracker.{Detail, Rounding, ProjectTimeSummary, TimeSummary}
   alias Number.Delimit
@@ -18,7 +18,7 @@ defmodule InvoiceTracker.TimeReporter do
   This report is suitable for generating the line items on an invoice.
   """
   @spec format_summary(TimeSummary.t, [{:rate, number}]) :: String.t
-  def format_summary(~m{%TimeSummary total projects}a, rate: rate) do
+  def format_summary(~M{%TimeSummary total, projects}, rate: rate) do
     Table.new()
     |> Table.add_rows(project_rows(projects, rate))
     |> Table.put_header(["Hours", "Project", "Rate", "Amount"])
@@ -41,7 +41,7 @@ defmodule InvoiceTracker.TimeReporter do
   accomplished during the invoice period.
   """
   @spec format_details(TimeSummary.t) :: String.t
-  def format_details(~m{%TimeSummary projects}a) do
+  def format_details(~M{%TimeSummary projects}) do
     """
     ## Included
 
@@ -57,7 +57,7 @@ defmodule InvoiceTracker.TimeReporter do
     """ |> String.trim_trailing
   end
 
-  defp detail_line(~m{%Detail activity time}a) do
+  defp detail_line(~M{%Detail activity, time}) do
     "- #{activity} (#{format_hours(time)} hrs)"
   end
 
@@ -65,7 +65,7 @@ defmodule InvoiceTracker.TimeReporter do
     Enum.map(projects, &(project_row(&1, rate)))
   end
 
-  defp project_row(~m{%ProjectTimeSummary name time}a, rate) do
+  defp project_row(~M{%ProjectTimeSummary name, time}, rate) do
     [format_hours(time), name, rate, format_amount(time, rate)]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule InvoiceTracker.Mixfile do
       {:mock, "~> 0.3.1", only: :test},
       {:number, "~> 0.5.1"},
       {:poison, "~> 3.1"},
-      {:short_maps, "~> 0.1.2"},
+      {:shorter_maps, "~> 2.2"},
       {:table_rex, "~> 0.10"},
       {:tesla, "~> 0.9.0"},
       {:timex, "~> 3.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -20,6 +20,7 @@
   "number": {:hex, :number, "0.5.4", "221ee2988dc3abaa3bd4dce43cbe603f20c8ca7343fc160769434fddd19c6fc0", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}, {:decimal_arithmetic, "~> 0.1", [hex: :decimal_arithmetic, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "short_maps": {:hex, :short_maps, "0.1.2", "a7c2bfd91179cdbdfe90e74a023992335d116982fa672612c74776b2e9257a7b", [], [], "hexpm"},
+  "shorter_maps": {:hex, :shorter_maps, "2.2.4", "69b54de2f5a744964b4c1748d2d111a6fea34fa7440af03f8161be6655e703f0", [], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "table_rex": {:hex, :table_rex, "0.10.0", "d981954370c00645c32ff7719c105db90ba6a9aa3e951c4d68eaeae3e0bfd40f", [:mix], [], "hexpm"},
   "tesla": {:hex, :tesla, "0.9.0", "db5c86895b63e698bbc61d62b4fd32735112de80ed82dcceef3660679fed9324", [:mix], [{:exjsx, ">= 0.1.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.2", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},

--- a/test/features_test.exs
+++ b/test/features_test.exs
@@ -3,7 +3,7 @@ defmodule FeaturesTest do
 
   use ExUnit.Case, async: true
 
-  import ShortMaps
+  import ShorterMaps
 
   @moduletag :features
 
@@ -21,7 +21,7 @@ defmodule FeaturesTest do
   end
 
   describe "end to end" do
-    test "shows active invoices in a table", ~m{file}a do
+    test "shows active invoices in a table", ~M{file} do
       assert list_invoices(file) == """
       +------------+-----+----------+------+
       |    Date    |  #  |  Amount  | Paid |
@@ -32,7 +32,7 @@ defmodule FeaturesTest do
       """
     end
 
-    test "shows all recorded invoices in a table", ~m{file}a do
+    test "shows all recorded invoices in a table", ~M{file} do
       assert list_all_invoices(file) == """
       +------------+-----+----------+------------+
       |    Date    |  #  |  Amount  |    Paid    |
@@ -45,7 +45,7 @@ defmodule FeaturesTest do
       """
     end
 
-    test "reports invoice status as of a date", ~m{file}a do
+    test "reports invoice status as of a date", ~M{file} do
       assert invoice_status(file, "2017-03-31", "2017-03-17") === """
       +----------------------------------------------------------------------+
       |                   Invoice status as of 2017-03-31                    |

--- a/test/invoice_reporter_test.exs
+++ b/test/invoice_reporter_test.exs
@@ -3,7 +3,7 @@ defmodule InvoiceReporterTest do
 
   use ExUnit.Case
 
-  import ShortMaps
+  import ShorterMaps
 
   alias InvoiceTracker.{Invoice, InvoiceReporter}
 
@@ -12,12 +12,12 @@ defmodule InvoiceReporterTest do
       {:ok, invoices: []}
     end
 
-    test "reports that the list is empty", ~m{invoices}a do
+    test "reports that the list is empty", ~M{invoices} do
       output = InvoiceReporter.format_list(invoices)
       assert output == "No invoices found\n"
     end
 
-    test "reports that the status report is empty", ~m{invoices}a do
+    test "reports that the status report is empty", ~M{invoices} do
       output = InvoiceReporter.format_status(invoices, ~D[2017-03-30])
       assert output == "No active invoices\n"
     end
@@ -38,7 +38,7 @@ defmodule InvoiceReporterTest do
       {:ok, invoices: invoices}
     end
 
-    test "nicely formats the list", ~m{invoices}a do
+    test "nicely formats the list", ~M{invoices} do
       output = InvoiceReporter.format_list(invoices)
       assert output == """
       +------------+-----+------------+------------+
@@ -51,7 +51,7 @@ defmodule InvoiceReporterTest do
       """
     end
 
-    test "nicely formats the status report", ~m{invoices}a do
+    test "nicely formats the status report", ~M{invoices} do
       output = InvoiceReporter.format_status(invoices, ~D[2017-01-15])
       assert output == """
       +--------------------------------------------------------------------------+

--- a/test/invoice_test.exs
+++ b/test/invoice_test.exs
@@ -3,7 +3,7 @@ defmodule InvoiceTest do
 
   use ExUnit.Case
 
-  import ShortMaps
+  import ShorterMaps
 
   alias InvoiceTracker.Invoice
 
@@ -14,71 +14,71 @@ defmodule InvoiceTest do
   end
 
   describe "paying an invoice" do
-    test "marks the invoice as paid", ~m{paid}a do
+    test "marks the invoice as paid", ~M{paid} do
       assert Invoice.paid?(paid)
     end
 
-    test "records the payment date", ~m{paid}a do
+    test "records the payment date", ~M{paid} do
       assert paid.paid_on == ~D[2017-02-07]
     end
   end
 
   describe "due date" do
-    test "invoices are due 15 days after issue", ~m{invoice}a do
+    test "invoices are due 15 days after issue", ~M{invoice} do
       assert Invoice.due_on(invoice) == ~D[2017-01-16]
     end
   end
 
   describe "has activity since a given date" do
-    test "unpaid invoices have activity", ~m{invoice}a do
+    test "unpaid invoices have activity", ~M{invoice} do
       assert Invoice.active_since?(invoice, ~D[2017-01-31])
     end
 
-    test "issued invoices have activity", ~m{invoice}a do
+    test "issued invoices have activity", ~M{invoice} do
       assert Invoice.active_since?(invoice, ~D[2016-12-20])
     end
 
-    test "invoices paid before the date do not have activity", ~m{paid}a do
+    test "invoices paid before the date do not have activity", ~M{paid} do
       refute Invoice.active_since?(paid, ~D[2017-02-13])
     end
 
-    test "invoices paid on the date do not have activity", ~m{paid}a do
+    test "invoices paid on the date do not have activity", ~M{paid} do
       refute Invoice.active_since?(paid, paid.paid_on)
     end
 
-    test "invoices paid after the date have activity", ~m{paid}a do
+    test "invoices paid after the date have activity", ~M{paid} do
       assert Invoice.active_since?(paid, ~D[2017-02-01])
     end
   end
 
   describe "status" do
-    test "current if before due date", ~m{invoice}a do
+    test "current if before due date", ~M{invoice} do
       assert Invoice.status(invoice, ~D[2017-01-07]) == "Current"
     end
 
-    test "current if on due date", ~m{invoice}a do
+    test "current if on due date", ~M{invoice} do
       assert Invoice.status(invoice, Invoice.due_on(invoice)) == "Current"
     end
 
-    test "late if unpaid after due date", ~m{invoice}a do
+    test "late if unpaid after due date", ~M{invoice} do
       assert Invoice.status(invoice, ~D[2017-03-01]) == "44 days late"
     end
 
-    test "paid on time if paid by due date", ~m{invoice}a do
+    test "paid on time if paid by due date", ~M{invoice} do
       paid = Invoice.pay(invoice, ~D[2017-01-07])
       assert Invoice.status(paid, ~D[2017-01-31]) == "Paid on time"
     end
 
-    test "paid on time if paid on due date", ~m{invoice}a do
+    test "paid on time if paid on due date", ~M{invoice} do
       paid = Invoice.pay(invoice, Invoice.due_on(invoice))
       assert Invoice.status(paid, ~D[2017-01-31]) == "Paid on time"
     end
 
-    test "late if paid after due date", ~m{paid}a do
+    test "late if paid after due date", ~M{paid} do
       assert Invoice.status(paid, ~D[2017-03-01]) == "22 days late"
     end
 
-    test "uses singular 'day' when one day late", ~m{invoice}a do
+    test "uses singular 'day' when one day late", ~M{invoice} do
       assert Invoice.status(invoice, ~D[2017-01-17]) == "1 day late"
     end
   end

--- a/test/time_reporter_test.exs
+++ b/test/time_reporter_test.exs
@@ -3,7 +3,7 @@ defmodule TimeReporterTest do
 
   use ExUnit.Case
 
-  import ShortMaps
+  import ShorterMaps
 
   alias InvoiceTracker.{Detail, ProjectTimeSummary, TimeReporter, TimeSummary}
   alias Timex.Duration
@@ -35,7 +35,7 @@ defmodule TimeReporterTest do
       {:ok, [summary: summary]}
     end
 
-    test "nicely formats the summary", ~m{summary}a do
+    test "nicely formats the summary", ~M{summary} do
       output = TimeReporter.format_summary(summary, rate: 100)
       assert output == """
       +-------+-----------------+------+----------+
@@ -49,7 +49,7 @@ defmodule TimeReporterTest do
       """
     end
 
-    test "nicely formats the details", ~m{summary}a do
+    test "nicely formats the details", ~M{summary} do
       output = TimeReporter.format_details(summary)
       assert output == ~S"""
       ## Included

--- a/test/time_summary_test.exs
+++ b/test/time_summary_test.exs
@@ -3,7 +3,7 @@ defmodule TimeSummaryTest do
 
   use ExUnit.Case
 
-  import ShortMaps
+  import ShorterMaps
 
   alias InvoiceTracker.{Detail, ProjectTimeSummary, TimeSummary}
   alias Timex.Duration
@@ -35,17 +35,17 @@ defmodule TimeSummaryTest do
   end
 
   describe "rounding" do
-    test "rounds total hours", ~m{summary}a do
+    test "rounds total hours", ~M{summary} do
       assert Duration.to_hours(summary.total) == 7.7
     end
 
     test "rounds and adjusts project hours to match total",
-      %{summary: ~m{projects}a} do
+      %{summary: ~M{projects}} do
         assert Enum.map(projects, &(Duration.to_hours(&1.time))) == [4.1, 3.6]
     end
 
     test "rounds and adjusts detail hours to match rounded project total",
-      %{summary: ~m{projects}a} do
+      %{summary: ~M{projects}} do
       assert Enum.flat_map(projects, fn project ->
         Enum.map(project.details, &(Duration.to_hours(&1.time)))
       end) === [1.3, 2.8, 3.6]

--- a/test/toggl_response_test.exs
+++ b/test/toggl_response_test.exs
@@ -3,7 +3,7 @@ defmodule TogglResponseTest do
 
   use ExUnit.Case
 
-  import ShortMaps
+  import ShorterMaps
 
   alias InvoiceTracker.{Detail, TogglResponse}
   alias Timex.Duration
@@ -35,11 +35,11 @@ defmodule TogglResponseTest do
     {:ok, summary: summary}
   end
 
-  test "reads total time", ~m{summary}a do
+  test "reads total time", ~M{summary} do
     assert summary.total == Duration.from_milliseconds(123_456_789)
   end
 
-  test "extracts project time entries", ~m{summary}a do
+  test "extracts project time entries", ~M{summary} do
     projects = Enum.map(summary.projects, &(Map.take(&1, [:name, :time])))
     assert projects == [
       %{
@@ -53,7 +53,7 @@ defmodule TogglResponseTest do
     ]
   end
 
-  test "extracts activity details", ~m{summary}a do
+  test "extracts activity details", ~M{summary} do
     assert Enum.flat_map(summary.projects, &(&1.details)) == [
       %Detail{
         activity: "Entry the First",


### PR DESCRIPTION
ShorterMaps provides a more direct syntax when keys are atoms, and also allows more flexibility in how maps are specified.