### PR TITLE
⬆️Upgrade to latest Elixir/Erlang versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ jobs:
   build:
     docker:
       # Bump cache key versions below when changing elixir version
-      - image: circleci/elixir:1.8.2
+      - image: circleci/elixir:1.9.2
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v5-dependency-cache-{{ checksum "mix.lock" }}
-            - v5-dependency-cache
+            - v6-dependency-cache-{{ checksum "mix.lock" }}
+            - v6-dependency-cache
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get
@@ -20,18 +20,18 @@ jobs:
           environment:
             MIX_ENV: test
       - save_cache:
-          key: v5-dependency-cache-{{ checksum "mix.lock" }}
+          key: v6-dependency-cache-{{ checksum "mix.lock" }}
           paths:
             - _build
             - deps
             - ~/.mix
       - restore_cache:
           keys:
-            - v5-plt-cache-{{ checksum "mix.lock" }}
-            - v5-plt-cache
+            - v6-plt-cache-{{ checksum "mix.lock" }}
+            - v6-plt-cache
       - run: mix dialyzer --plt
       - save_cache:
-          key: v5-plt-cache-{{ checksum "mix.lock" }}
+          key: v6-plt-cache-{{ checksum "mix.lock" }}
           paths:
             - _build
             - ~/.mix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,15 +2,14 @@ version: 2
 jobs:
   build:
     docker:
-      # Bump cache key version below when changing elixir version
-      - image: circleci/elixir:1.5.3
-    # resource_class: medium+
+      # Bump cache key versions below when changing elixir version
+      - image: circleci/elixir:1.6.6
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v3-dependency-cache-{{ checksum "mix.lock" }}
-            - v3-dependency-cache
+            - v4-dependency-cache-{{ checksum "mix.lock" }}
+            - v4-dependency-cache
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get
@@ -21,18 +20,18 @@ jobs:
           environment:
             MIX_ENV: test
       - save_cache:
-          key: v3-dependency-cache-{{ checksum "mix.lock" }}
+          key: v4-dependency-cache-{{ checksum "mix.lock" }}
           paths:
             - _build
             - deps
             - ~/.mix
       - restore_cache:
           keys:
-            - v3-plt-cache-{{ checksum "mix.lock" }}
-            - v3-plt-cache
+            - v4-plt-cache-{{ checksum "mix.lock" }}
+            - v4-plt-cache
       - run: mix dialyzer --plt
       - save_cache:
-          key: v3-plt-cache-{{ checksum "mix.lock" }}
+          key: v4-plt-cache-{{ checksum "mix.lock" }}
           paths:
             - _build
             - ~/.mix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ jobs:
   build:
     docker:
       # Bump cache key versions below when changing elixir version
-      - image: circleci/elixir:1.6.6
+      - image: circleci/elixir:1.7.4-otp-21
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v4-dependency-cache-{{ checksum "mix.lock" }}
-            - v4-dependency-cache
+            - v5-dependency-cache-{{ checksum "mix.lock" }}
+            - v5-dependency-cache
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get
@@ -20,18 +20,18 @@ jobs:
           environment:
             MIX_ENV: test
       - save_cache:
-          key: v4-dependency-cache-{{ checksum "mix.lock" }}
+          key: v5-dependency-cache-{{ checksum "mix.lock" }}
           paths:
             - _build
             - deps
             - ~/.mix
       - restore_cache:
           keys:
-            - v4-plt-cache-{{ checksum "mix.lock" }}
-            - v4-plt-cache
+            - v5-plt-cache-{{ checksum "mix.lock" }}
+            - v5-plt-cache
       - run: mix dialyzer --plt
       - save_cache:
-          key: v4-plt-cache-{{ checksum "mix.lock" }}
+          key: v5-plt-cache-{{ checksum "mix.lock" }}
           paths:
             - _build
             - ~/.mix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # Bump cache key versions below when changing elixir version
-      - image: circleci/elixir:1.7.4
+      - image: circleci/elixir:1.8.2
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # Bump cache key versions below when changing elixir version
-      - image: circleci/elixir:1.7.4-otp-21
+      - image: circleci/elixir:1.7.4
     steps:
       - checkout
       - restore_cache:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 20.1
-elixir 1.5.3
+elixir 1.6.6

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 21.3
-elixir 1.8.2
+erlang 22.1
+elixir 1.9.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 20.1
-elixir 1.6.6
+erlang 21.3
+elixir 1.7.4-otp-21

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 21.3
-elixir 1.7.4-otp-21
+elixir 1.8.2

--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -74,7 +74,6 @@
         #
         {Credo.Check.Design.TagTODO, exit_status: 2},
         {Credo.Check.Design.TagFIXME},
-
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 98},
@@ -92,7 +91,6 @@
         {Credo.Check.Readability.VariableNames},
         {Credo.Check.Readability.Semicolons},
         {Credo.Check.Readability.SpaceAfterCommas},
-
         {Credo.Check.Refactor.DoubleBooleanNegation},
         {Credo.Check.Refactor.CondStatements},
         {Credo.Check.Refactor.CyclomaticComplexity},
@@ -104,7 +102,6 @@
         {Credo.Check.Refactor.Nesting},
         {Credo.Check.Refactor.PipeChainStart},
         {Credo.Check.Refactor.UnlessWithElse},
-
         {Credo.Check.Warning.BoolOperationOnSameValues},
         {Credo.Check.Warning.ExpensiveEmptyEnumCheck},
         {Credo.Check.Warning.IExPry},

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule InvoiceTracker.Mixfile do
       {:credo, "~> 0.8.10", only: [:dev, :test]},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:mix_test_watch, "~> 0.3", only: :dev, runtime: false},
-      {:mock, "~> 0.3.1", only: :test},
+      {:mock, "~> 0.3.3", only: :test},
       {:number, "~> 0.5.1"},
       {:poison, "~> 3.1"},
       {:shorter_maps, "~> 2.2"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], [], "hexpm"},
+%{
+  "briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], []},
   "combine": {:hex, :combine, "0.9.6", "8d1034a127d4cbf6924c8a5010d3534d958085575fa4d9b878f200d79ac78335", [:mix], [], "hexpm"},
@@ -11,12 +12,12 @@
   "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.7.1", "e238c52c5df3c3b16ce613d3a51c7220a784d734879b1e231c9babd433ac1cb4", [:rebar3], [{:certifi, "1.0.0", [hex: :certifi, optional: false]}, {:idna, "4.0.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], []},
-  "meck": {:hex, :meck, "0.8.8", "eeb3efe811d4346e1a7f65b2738abc2ad73cbe1a2c91b5dd909bac2ea0414fa6", [:rebar3], [], "hexpm"},
+  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.5.0", "2c322d119a4795c3431380fca2bca5afa4dc07324bd3c0b9f6b2efbdd99f5ed3", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
-  "mock": {:hex, :mock, "0.3.1", "994f00150f79a0ea50dc9d86134cd9ebd0d177ad60bd04d1e46336cdfdb98ff9", [:mix], [{:meck, "~> 0.8.8", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
+  "mock": {:hex, :mock, "0.3.3", "42a433794b1291a9cf1525c6d26b38e039e0d3a360732b5e467bfc77ef26c914", [:mix], [{:meck, "~> 0.8.13", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "number": {:hex, :number, "0.5.4", "221ee2988dc3abaa3bd4dce43cbe603f20c8ca7343fc160769434fddd19c6fc0", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}, {:decimal_arithmetic, "~> 0.1", [hex: :decimal_arithmetic, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "short_maps": {:hex, :short_maps, "0.1.2", "a7c2bfd91179cdbdfe90e74a023992335d116982fa672612c74776b2e9257a7b", [], [], "hexpm"},
@@ -25,4 +26,5 @@
   "table_rex": {:hex, :table_rex, "1.0.0", "587f0668012ceeda1ff62661221d4400ef551c95f1c63d7f78a3168eeee08ca3", [:mix], [], "hexpm"},
   "tesla": {:hex, :tesla, "0.10.0", "e588c7e7f1c0866c81eeed5c38f02a4a94d6309eede336c1e6ca08b0a95abd3f", [:mix], [{:exjsx, ">= 0.1.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.2", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
   "timex": {:hex, :timex, "3.1.24", "d198ae9783ac807721cca0c5535384ebdf99da4976be8cefb9665a9262a1e9e3", [:mix], [{:combine, "~> 0.7", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
-  "tzdata": {:hex, :tzdata, "0.1.201605", "0c4184819b9d6adedcc02107b68321c45d8e853def7a32629b7961b9f2e95f33", [:mix], [], "hexpm"}}
+  "tzdata": {:hex, :tzdata, "0.1.201605", "0c4184819b9d6adedcc02107b68321c45d8e853def7a32629b7961b9f2e95f33", [:mix], [], "hexpm"},
+}

--- a/test/features_test.exs
+++ b/test/features_test.exs
@@ -17,12 +17,12 @@ defmodule FeaturesTest do
     record_invoice(file, "1322.28", "2017-03-16")
     record_payment(file, "99", "2017-03-20")
     record_payment(file, "2017-02-15")
-    {:ok, file: file}
+    {:ok, invoice_file: file}
   end
 
   describe "end to end" do
-    test "shows active invoices in a table", ~M{file} do
-      assert list_invoices(file) == """
+    test "shows active invoices in a table", ~M{invoice_file} do
+      assert list_invoices(invoice_file) == """
              +------------+-----+----------+------+
              |    Date    |  #  |  Amount  | Paid |
              +------------+-----+----------+------+
@@ -32,8 +32,8 @@ defmodule FeaturesTest do
              """
     end
 
-    test "shows all recorded invoices in a table", ~M{file} do
-      assert list_all_invoices(file) == """
+    test "shows all recorded invoices in a table", ~M{invoice_file} do
+      assert list_all_invoices(invoice_file) == """
              +------------+-----+----------+------------+
              |    Date    |  #  |  Amount  |    Paid    |
              +------------+-----+----------+------------+
@@ -45,8 +45,8 @@ defmodule FeaturesTest do
              """
     end
 
-    test "reports invoice status as of a date", ~M{file} do
-      assert invoice_status(file, "2017-03-31", "2017-03-17") === """
+    test "reports invoice status as of a date", ~M{invoice_file} do
+      assert invoice_status(invoice_file, "2017-03-31", "2017-03-17") === """
              +----------------------------------------------------------------------+
              |                   Invoice status as of 2017-03-31                    |
              +------------+-----+----------+------------+------------+--------------+


### PR DESCRIPTION
Now on Elixir 1.9.2/Erlang 22.1.

Changes required:
- `:dets.open_file` was failing with an argument error in Erlang 21; modified to pass the filename through `to_charlist` first.

- `:dets.open_file`'s API seems to have changed in Erlang 21, but I couldn't find any documentation on it.  The variant that takes a filename no longer takes any args, which is what we were using.  We no longer need the args (`access` setting), but that resulted in an `ENOENT` error when first creating the invoices file.  Switched to the alternative API instead, and that seems to be working.

- Added an explicit `sync` call to ensure changes are flushed to the invoices file.  Feature tests were failing with missing entries otherwise.

- Renamed file -> invoice_file in features test; file was overriding ExUnit's variable that was used to print the filename for failing tests

- Upgraded to mock v0.3.3 in order to pick up an Elixir 1.8 fix in the underlying meck library.